### PR TITLE
Fix typos

### DIFF
--- a/gtk3/config_widget.c
+++ b/gtk3/config_widget.c
@@ -611,7 +611,7 @@ fcitx_config_widget_setup_ui(FcitxConfigWidget *self)
         self->advanceCheckBox = gtk_check_button_new();
         gtk_grid_attach(GTK_GRID(self), self->advanceCheckBox, 0, 1, 1, 1);
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->advanceCheckBox), FALSE);
-        gtk_button_set_label(GTK_BUTTON(self->advanceCheckBox), _("Show Advance Option"));
+        gtk_button_set_label(GTK_BUTTON(self->advanceCheckBox), _("Show Advanced Options"));
         g_signal_connect(self->advanceCheckBox, "toggled", (GCallback) _fcitx_config_widget_toggle_simple_full, self);
         _fcitx_config_widget_toggle_simple_full(GTK_TOGGLE_BUTTON(self->advanceCheckBox), self);
     }

--- a/gtk3/main_window.c
+++ b/gtk3/main_window.c
@@ -280,7 +280,7 @@ void _fcitx_main_window_add_addon_page(FcitxMainWindow* self)
     GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 
     /* advance check box */
-    self->advancecheckbox = gtk_check_button_new_with_label(_("Advance"));
+    self->advancecheckbox = gtk_check_button_new_with_label(_("Advanced"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(self->advancecheckbox), FALSE);
     g_signal_connect(G_OBJECT(self->advancecheckbox), "toggled", G_CALLBACK(_fcitx_main_window_checkbox_changed), self);
 

--- a/po/de.po
+++ b/po/de.po
@@ -30,7 +30,7 @@ msgid "Addon"
 msgstr "Addon"
 
 #: gtk3/main_window.c:283
-msgid "Advance"
+msgid "Advanced"
 msgstr "Fortschritt"
 
 #: gtk3/main_window.c:221
@@ -132,7 +132,7 @@ msgid "Search Input Method"
 msgstr "Eingabemethode suchen"
 
 #: gtk3/config_widget.c:614
-msgid "Show Advance Option"
+msgid "Show Advanced Options"
 msgstr "Erweiterte Einstellungen anzeigen"
 
 #: gtk/im_widget.c:192 gtk3/im_widget.ui:87

--- a/po/fcitx-configtool.pot
+++ b/po/fcitx-configtool.pot
@@ -26,7 +26,7 @@ msgid "Other"
 msgstr ""
 
 #: gtk3/config_widget.c:614
-msgid "Show Advance Option"
+msgid "Show Advanced Options"
 msgstr ""
 
 #: gtk3/config_widget.c:937 gtk3/im_config_dialog.c:73 gtk3/im_dialog.c:127
@@ -106,7 +106,7 @@ msgid "Appearance"
 msgstr ""
 
 #: gtk3/main_window.c:283
-msgid "Advance"
+msgid "Advanced"
 msgstr ""
 
 #: gtk3/main_window.c:294

--- a/po/ja.po
+++ b/po/ja.po
@@ -30,7 +30,7 @@ msgid "Addon"
 msgstr "アドオン"
 
 #: gtk3/main_window.c:283
-msgid "Advance"
+msgid "Advanced"
 msgstr "拡張"
 
 #: gtk3/main_window.c:221
@@ -132,7 +132,7 @@ msgid "Search Input Method"
 msgstr "入力メソッドの検索"
 
 #: gtk3/config_widget.c:614
-msgid "Show Advance Option"
+msgid "Show Advanced Options"
 msgstr "拡張オプションの表示"
 
 #: gtk/im_widget.c:192 gtk3/im_widget.ui:87

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -31,7 +31,7 @@ msgid "Addon"
 msgstr "附加组件"
 
 #: gtk3/main_window.c:283
-msgid "Advance"
+msgid "Advanced"
 msgstr "高级"
 
 #: gtk3/main_window.c:221
@@ -133,7 +133,7 @@ msgid "Search Input Method"
 msgstr "搜索输入法"
 
 #: gtk3/config_widget.c:614
-msgid "Show Advance Option"
+msgid "Show Advanced Options"
 msgstr "显示高级选项"
 
 #: gtk/im_widget.c:192 gtk3/im_widget.ui:87

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -31,7 +31,7 @@ msgid "Addon"
 msgstr "附加元件"
 
 #: gtk3/main_window.c:283
-msgid "Advance"
+msgid "Advanced"
 msgstr "進階"
 
 #: gtk3/main_window.c:221
@@ -133,7 +133,7 @@ msgid "Search Input Method"
 msgstr "搜尋輸入法"
 
 #: gtk3/config_widget.c:614
-msgid "Show Advance Option"
+msgid "Show Advanced Options"
 msgstr "顯示進階選項"
 
 #: gtk/im_widget.c:192 gtk3/im_widget.ui:87


### PR DESCRIPTION
"Advance" should be spelled as "Advanced" in this context.
