### PR TITLE
Improve search while filtering input methods

### DIFF
--- a/gtk3/im_dialog.c
+++ b/gtk3/im_dialog.c
@@ -361,10 +361,10 @@ gboolean _fcitx_im_dialog_filter_func(GtkTreeModel *model,
             const char* language = gdm_get_language_from_name(item->langcode, NULL);
             flag = flag && (
                         strlen(filter_text) == 0
-                     || strstr(item->name, filter_text)
-                     || strstr(item->unique_name, filter_text)
-                     || strstr(item->langcode, filter_text)
-                     || (language && strstr(language, filter_text)));
+                     || strcasestr(item->name, filter_text)
+                     || strcasestr(item->unique_name, filter_text)
+                     || strcasestr(item->langcode, filter_text)
+                     || (language && strcasestr(language, filter_text)));
 
             gchar temp[3] = {0, 0, 0};
             strncpy(temp, item->langcode, 2);

--- a/gtk3/im_dialog.c
+++ b/gtk3/im_dialog.c
@@ -358,11 +358,13 @@ gboolean _fcitx_im_dialog_filter_func(GtkTreeModel *model,
     gboolean flag = TRUE;
     if (item) {
         if (strcmp(item->unique_name, "fcitx-keyboard-us") != 0) {
+            const char* language = gdm_get_language_from_name(item->langcode, NULL);
             flag = flag && (
                         strlen(filter_text) == 0
                      || strstr(item->name, filter_text)
                      || strstr(item->unique_name, filter_text)
-                     || strstr(item->langcode, filter_text));
+                     || strstr(item->langcode, filter_text)
+                     || (language && strstr(language, filter_text)));
 
             gchar temp[3] = {0, 0, 0};
             strncpy(temp, item->langcode, 2);

--- a/gtk3/im_dialog.c
+++ b/gtk3/im_dialog.c
@@ -358,13 +358,14 @@ gboolean _fcitx_im_dialog_filter_func(GtkTreeModel *model,
     gboolean flag = TRUE;
     if (item) {
         if (strcmp(item->unique_name, "fcitx-keyboard-us") != 0) {
-            const char* language = gdm_get_language_from_name(item->langcode, NULL);
+            char* language = gdm_get_language_from_name(item->langcode, NULL);
             flag = flag && (
                         strlen(filter_text) == 0
                      || strcasestr(item->name, filter_text)
                      || strcasestr(item->unique_name, filter_text)
                      || strcasestr(item->langcode, filter_text)
                      || (language && strcasestr(language, filter_text)));
+            g_free(language);
 
             gchar temp[3] = {0, 0, 0};
             strncpy(temp, item->langcode, 2);


### PR DESCRIPTION
Two changes:

- Input methods can be filtered from the language they target. 
   -> You can type "Chinese" to find "Pinyin". Previously you had to type "Pinyin".
- Use case-insensitive search when filtering languages
   -> You can type "french" to find "French". Previously the case had to be an exact match.