### PR TITLE
some configuration can not work until fcitx is restarted.

### DIFF
--- a/gtk/main_window.c
+++ b/gtk/main_window.c
@@ -44,6 +44,17 @@ enum {
     PAGE_N_COLUMNS
 };
 
+gboolean reboot_fcitx(GtkApplication *self, GdkEvent *event, gpointer data)
+{
+    GError* error;
+    gchar* argv[3];
+    argv[0] = EXEC_PREFIX "/bin/fcitx";
+    argv[1] = "-r";
+    argv[2] = 0;
+    g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &error);
+    return FALSE;
+}
+
 G_DEFINE_TYPE(FcitxMainWindow, fcitx_main_window, GTK_TYPE_WINDOW)
 
 static void fcitx_main_window_finalize(GObject* object);
@@ -140,6 +151,8 @@ fcitx_main_window_init(FcitxMainWindow* self)
     g_signal_connect_swapped(G_OBJECT(self), "destroy", G_CALLBACK(gtk_main_quit), NULL);
     g_signal_connect(G_OBJECT(self->pageview), "selection-changed",
                      G_CALLBACK(_fcitx_main_window_selection_changed_cb), self);
+    
+    g_signal_connect(G_OBJECT(self), "delete_event", G_CALLBACK(reboot_fcitx), NULL);
 
     GtkTreePath* path = gtk_tree_model_get_path(GTK_TREE_MODEL(self->pagestore), &self->impage->iter);
     gtk_icon_view_select_path(GTK_ICON_VIEW(self->pageview), path);

--- a/gtk3/main_window.c
+++ b/gtk3/main_window.c
@@ -40,6 +40,17 @@ enum {
 
 G_DEFINE_TYPE(FcitxMainWindow, fcitx_main_window, GTK_TYPE_WINDOW)
 
+gboolean reboot_fcitx(GtkApplication *self, GdkEvent *event, gpointer data)
+{
+    GError* error;
+    gchar* argv[3];
+    argv[0] = EXEC_PREFIX "/bin/fcitx";
+    argv[1] = "-r";
+    argv[2] = 0;
+    g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, &error);
+    return FALSE;
+}
+
 static void fcitx_main_window_finalize(GObject* object);
 
 static void _fcitx_main_window_add_config_file_page(FcitxMainWindow* self);
@@ -104,6 +115,8 @@ fcitx_main_window_init(FcitxMainWindow* self)
     gtk_container_add(GTK_CONTAINER(self), vbox);
     gtk_window_set_icon_name(GTK_WINDOW(self), "fcitx");
     gtk_window_set_title(GTK_WINDOW(self), _("Input Method Configuration"));
+
+    g_signal_connect(self, "delete_event", G_CALLBACK(reboot_fcitx), NULL);
 }
 
 GtkWidget*


### PR DESCRIPTION
之前跟您讨论过系统托盘的设置没法立即生效问题，这几天尝试了几种方案，最后使用了折中的方案，关闭fcitx-config-gtk后，重启下fcitx。您看一下，是否有必要合入。或者给后面遇到同样问题的人一个参考方案。